### PR TITLE
Improve dist metadata and added some entries to SEE ALSO

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for Export::Lexical
 
 0.0.6
     - Added github repo to dist metadata.
+    - Added min perl version to dist metadata.
 
 0.0.5  Sat Oct  3 11:32:12 PDT 2015
     - License changed to MIT.

--- a/Changes
+++ b/Changes
@@ -3,6 +3,8 @@ Revision history for Export::Lexical
 0.0.6
     - Added github repo to dist metadata.
     - Added min perl version to dist metadata.
+    - Fixed pod warning
+    - Added SEE ALSO entries for other lexical scope related exporter modules.
 
 0.0.5  Sat Oct  3 11:32:12 PDT 2015
     - License changed to MIT.

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Export::Lexical
 
+0.0.6
+    - Added github repo to dist metadata.
+
 0.0.5  Sat Oct  3 11:32:12 PDT 2015
     - License changed to MIT.
     - Addressed CPAN Testers report

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use ExtUtils::MakeMaker;
 
-WriteMakefile(
+my %WriteMakefileArgs = (
     NAME                => 'Export::Lexical',
     AUTHOR              => 'Chris Grau <cgrau@cpan.org>',
     VERSION_FROM        => 'lib/Export/Lexical.pm',
@@ -17,6 +17,21 @@ WriteMakefile(
         'Test::Exception'  => 0,
         'Test::Warn'       => 0,
     },
+    "META_MERGE" => {
+        'meta-spec' => { version => 2 },
+        resources => {
+            repository  => {
+                type => 'git',
+                web  => 'https://github.com/sirhc/perl-Export-Lexical',
+                url  => 'https://github.com/sirhc/perl-Export-Lexical.git',
+            },
+        },
+    },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => 'Export-Lexical-*' },
 );
+
+delete $WriteMakefileArgs{META_MERGE}
+    unless eval { ExtUtils::MakeMaker->VERSION(6.45) };
+
+WriteMakefile(%WriteMakefileArgs);

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,6 +17,7 @@ my %WriteMakefileArgs = (
         'Test::Exception'  => 0,
         'Test::Warn'       => 0,
     },
+    "MIN_PERL_VERSION" => 5.01,
     "META_MERGE" => {
         'meta-spec' => { version => 2 },
         resources => {
@@ -33,5 +34,8 @@ my %WriteMakefileArgs = (
 
 delete $WriteMakefileArgs{META_MERGE}
     unless eval { ExtUtils::MakeMaker->VERSION(6.45) };
+
+delete $WriteMakefileArgs{MIN_PERL_VERSION}
+    unless eval { ExtUtils::MakeMaker->VERSION(6.48) };
 
 WriteMakefile(%WriteMakefileArgs);

--- a/lib/Export/Lexical.pm
+++ b/lib/Export/Lexical.pm
@@ -259,11 +259,20 @@ This module is an expansion of an idea presented by Damian Conway.
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2008–2015, Christopher D. Grau.
+Copyright 2008-2015, Christopher D. Grau.
 
 This is free software, licensed under the MIT (X11) License.
 
 =head1 SEE ALSO
+
+L<Exporter::Lexical> is another exporter module which provides for lexically
+scoped imports.
+
+L<Lexical::Import> lets you import functions and variables from another
+package into the importing lexical namespace.
+
+L<Exporter::LexicalVars> has a similar name, but it lets you export lexical (my)
+variables from your module.
 
 L<perlpragma>
 

--- a/lib/Export/Lexical.pm
+++ b/lib/Export/Lexical.pm
@@ -6,7 +6,7 @@ use warnings;
 use B;
 use Carp;
 
-our $VERSION = '0.0.5';
+our $VERSION = '0.0.6';
 
 my %exports_for  = ();
 my %modifier_for = ();  # e.g., $modifier_for{$pkg} = 'silent'


### PR DESCRIPTION
Hi Chris,

This adds the github repo to the dist's metadata, so it will appear in the sidebar on MetaCPAN. It also adds the min perl version to the dist metadata.

I added some links in SEE ALSO, for other module for doing lexical scoped exporting / importing of some kind.

Cheers,
Neil
